### PR TITLE
feat: add auth middleware

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,28 @@
+function requireAuth(req, res, next) {
+  if (!req.session || !req.session.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const { is_active } = req.session.user;
+  if (!is_active) {
+    return res.status(403).json({ message: 'User inactive' });
+  }
+
+  next();
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    requireAuth(req, res, () => {
+      if (req.session.user.role !== role) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      next();
+    });
+  };
+}
+
+module.exports = {
+  requireAuth,
+  requireRole,
+};


### PR DESCRIPTION
## Summary
- add authentication middleware checking session and user activity
- add role-based middleware building on auth

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a679bedcb883278e5bad84d7b34cff