### PR TITLE
feat: add basic auth and user routes

### DIFF
--- a/routes/app.js
+++ b/routes/app.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const { requireAuth } = require('./auth');
+
+const router = express.Router();
+
+router.get('/api/app/hello', requireAuth, (req, res) => {
+  res.json({ message: 'Hello from app!' });
+});
+
+module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const pool = require('../db');
+
+const router = express.Router();
+
+function requireAuth(req, res, next) {
+  if (req.session && req.session.user) {
+    return next();
+  }
+  return res.status(401).json({ error: 'Unauthorized' });
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.session || !req.session.user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    if (req.session.user.role !== role) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    return next();
+  };
+}
+
+router.post('/api/auth/login', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing username or password' });
+  }
+  try {
+    const { rows } = await pool.query('SELECT id, password, role FROM users WHERE username = $1', [username]);
+    const user = rows[0];
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    req.session.user = { id: user.id, username, role: user.role };
+    return res.json({ message: 'Login successful' });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/api/auth/logout', (req, res) => {
+  req.session.destroy(err => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Logout failed' });
+    }
+    res.clearCookie('connect.sid');
+    return res.json({ message: 'Logout successful' });
+  });
+});
+
+module.exports = { router, requireAuth, requireRole };

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,0 +1,94 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const pool = require('../db');
+const { requireRole } = require('./auth');
+
+const router = express.Router();
+
+router.use(requireRole('ADMIN'));
+
+router.get('/api/users', async (req, res) => {
+  const page = parseInt(req.query.page, 10) || 1;
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const offset = (page - 1) * limit;
+  try {
+    const { rows } = await pool.query(
+      'SELECT id, username, role FROM users ORDER BY id LIMIT $1 OFFSET $2',
+      [limit, offset]
+    );
+    return res.json(rows);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.post('/api/users', async (req, res) => {
+  const { username, password, role } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing username or password' });
+  }
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    const { rows } = await pool.query(
+      'INSERT INTO users (username, password, role) VALUES ($1, $2, $3) RETURNING id, username, role',
+      [username, hashed, role || 'USER']
+    );
+    return res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.put('/api/users/:id', async (req, res) => {
+  const { id } = req.params;
+  const { username, password, role } = req.body;
+  try {
+    const fields = [];
+    const values = [];
+    let idx = 1;
+    if (username) {
+      fields.push(`username = $${idx++}`);
+      values.push(username);
+    }
+    if (password) {
+      const hashed = await bcrypt.hash(password, 10);
+      fields.push(`password = $${idx++}`);
+      values.push(hashed);
+    }
+    if (role) {
+      fields.push(`role = $${idx++}`);
+      values.push(role);
+    }
+    if (fields.length === 0) {
+      return res.status(400).json({ error: 'No fields to update' });
+    }
+    values.push(id);
+    const query = `UPDATE users SET ${fields.join(', ')} WHERE id = $${idx} RETURNING id, username, role`;
+    const { rows } = await pool.query(query, values);
+    if (!rows[0]) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    return res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.delete('/api/users/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { rowCount } = await pool.query('DELETE FROM users WHERE id = $1', [id]);
+    if (rowCount === 0) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    return res.status(204).end();
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add authentication routes with session-based login/logout and role helpers
- add admin-only user CRUD with pagination
- add auth-protected hello route

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a679c03eec832790d16f9b2bccdccc