### PR TITLE
Add initial user table migration and seed script

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  password TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER users_update_trigger
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at();


### PR DESCRIPTION
## Summary
- add SQL migration for `users` table and `updated_at` trigger
- introduce seeding script that runs migration and inserts default admin user

## Testing
- `npm test`
- `node scripts/seed.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a679c10978832783e33734e5128ed3