### PR TITLE
Remove connection test to prevent pool closure

### DIFF
--- a/db.js
+++ b/db.js
@@ -8,20 +8,4 @@ if (!connectionString) {
 }
 
 const pool = new Pool({ connectionString });
-
-async function testConnection() {
-  try {
-    const { rows } = await pool.query('SELECT NOW()');
-    console.log('Conectado ao banco de dados. Hora atual:', rows[0].now);
-  } catch (err) {
-    console.error('Erro ao conectar ao banco de dados:', err);
-  } finally {
-    await pool.end();
-  }
-}
-
-if (require.main === module) {
-  testConnection();
-}
-
 module.exports = pool;


### PR DESCRIPTION
## Summary
- remove standalone connection test
- stop calling `pool.end()` and export only the pool

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a679c37b6483278a79582d1d8d633b