### PR TITLE
Add health check endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,6 +43,19 @@ app.get('/api/session', (req, res) => {
   }
 });
 
+app.get('/health', (req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/db-health', async (req, res) => {
+  try {
+    await pool.query('SELECT 1');
+    res.json({ db: 'up' });
+  } catch (err) {
+    res.status(500).json({ db: 'down' });
+  }
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);


### PR DESCRIPTION
## Summary
- add `/health` route returning `{ ok: true }`
- add `/db-health` route that checks database connectivity and returns `{ db: 'up' }`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a68358635c832793fb59789070c8cd