### PR TITLE
feat: secure session cookie and auto-create PG session table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ DATABASE_URL=postgres://usuario:senha@host:porta/banco
 npm run seed
 ```
 
-4. Inicie o servidor de desenvolvimento:
+4. A tabela de sessões é criada automaticamente ao iniciar o servidor. O `connect-pg-simple` executa o arquivo `node_modules/connect-pg-simple/table.sql` para gerar a tabela caso ela não exista. Se preferir criar manualmente, rode:
+
+```bash
+psql mydatabase < node_modules/connect-pg-simple/table.sql
+```
+
+5. Inicie o servidor de desenvolvimento:
 
 ```bash
 npm run dev

--- a/server.js
+++ b/server.js
@@ -22,11 +22,17 @@ app.use(express.urlencoded({ extended: true }));
 app.use(session({
   store: new pgSession({
     pool,
+    createTableIfMissing: true,
   }),
   secret: process.env.SESSION_SECRET || 'change_this_secret',
   resave: false,
   saveUninitialized: false,
   name: 'sid',
+  cookie: {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  },
 }));
 
 app.use(express.static('public'));


### PR DESCRIPTION
## Summary
- secure session cookies with httpOnly, lax sameSite, and conditional secure flag
- auto-create session table using connect-pg-simple
- document session table creation steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6841988f08327afb535f288c8e63e