### PR TITLE
Revamp users schema and role handling

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,15 +1,15 @@
 CREATE TABLE IF NOT EXISTS users (
-  id SERIAL PRIMARY KEY,
-  email TEXT NOT NULL UNIQUE,
-  username TEXT NOT NULL UNIQUE,
-  password TEXT NOT NULL,
-  role TEXT NOT NULL DEFAULT 'client',
-  is_active BOOLEAN NOT NULL DEFAULT true,
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT CHECK(role IN ('ADMIN', 'CLIENT')) NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT false,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE OR REPLACE FUNCTION update_updated_at()
+CREATE OR REPLACE FUNCTION set_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
   NEW.updated_at = NOW();
@@ -17,7 +17,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER users_update_trigger
+CREATE TRIGGER users_updated_at_trigger
 BEFORE UPDATE ON users
 FOR EACH ROW
-EXECUTE FUNCTION update_updated_at();
+EXECUTE FUNCTION set_updated_at();

--- a/public/admin.html
+++ b/public/admin.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <nav>
-    <span id="username"></span>
+    <span id="name"></span>
     <button id="logout" style="float:right">Sair</button>
   </nav>
   <main>
@@ -23,11 +23,11 @@
         return;
       }
       const { user } = await session.json();
-      if (!user || user.role !== 'admin') {
+      if (!user || user.role !== 'ADMIN') {
         window.location.href = '/login.html';
         return;
       }
-      document.getElementById('username').textContent = user.username;
+      document.getElementById('name').textContent = user.name;
 
       const res = await fetch('/api/users');
       if (res.ok) {
@@ -35,7 +35,7 @@
         const list = document.getElementById('user-list');
         users.forEach(u => {
           const li = document.createElement('li');
-          li.textContent = `${u.username} (${u.email}) - ${u.role}`;
+          li.textContent = `${u.name} (${u.email}) - ${u.role}`;
           list.appendChild(li);
         });
       }

--- a/public/client.html
+++ b/public/client.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <nav>
-    <span id="username"></span>
+    <span id="name"></span>
     <button id="logout" style="float:right">Sair</button>
   </nav>
   <main>
@@ -22,11 +22,11 @@
         return;
       }
       const { user } = await session.json();
-      if (!user || user.role !== 'client') {
+      if (!user || user.role !== 'CLIENT') {
         window.location.href = '/login.html';
         return;
       }
-      document.getElementById('username').textContent = user.username;
+      document.getElementById('name').textContent = user.name;
     }
     load();
 

--- a/public/login.html
+++ b/public/login.html
@@ -12,7 +12,7 @@
     <h1>Entrar</h1>
     <form id="login-form">
       <label>
-        E-mail ou usuário:
+        E-mail ou nome:
         <input type="text" name="login" required />
       </label>
       <br />
@@ -31,7 +31,7 @@
       if (res.ok) {
         const { user } = await res.json();
         if (user) {
-          window.location.href = user.role === 'admin' ? '/admin.html' : '/client.html';
+          window.location.href = user.role === 'ADMIN' ? '/admin.html' : '/client.html';
         }
       }
     }
@@ -52,7 +52,7 @@
       if (res.ok) {
         const session = await fetch('/api/session');
         const { user } = await session.json();
-        window.location.href = user.role === 'admin' ? '/admin.html' : '/client.html';
+        window.location.href = user.role === 'ADMIN' ? '/admin.html' : '/client.html';
       } else {
         const msg = await res.json();
         document.getElementById('error').textContent = msg.message || 'Erro no login';

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -10,7 +10,7 @@ router.post('/login', async (req, res) => {
 
   try {
     const { rows } = await pool.query(
-      'SELECT * FROM users WHERE email = $1 OR username = $1',
+      'SELECT * FROM users WHERE email = $1 OR name = $1',
       [login]
     );
 
@@ -19,7 +19,7 @@ router.post('/login', async (req, res) => {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
 
-    const isValid = await bcrypt.compare(password, user.password);
+    const isValid = await bcrypt.compare(password, user.password_hash);
     if (!isValid) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
@@ -27,7 +27,7 @@ router.post('/login', async (req, res) => {
     req.session.user = {
       id: user.id,
       email: user.email,
-      username: user.username,
+      name: user.name,
       is_active: user.is_active,
       role: user.role,
     };

--- a/routes/users.js
+++ b/routes/users.js
@@ -5,10 +5,10 @@ const { requireAuth, requireRole } = require('../middleware/auth');
 const router = express.Router();
 
 // List all users - only accessible to authenticated admins
-router.get('/', requireRole('admin'), async (req, res) => {
+router.get('/', requireRole('ADMIN'), async (req, res) => {
   try {
     const { rows } = await pool.query(
-      'SELECT id, email, username, role, is_active FROM users'
+      'SELECT id, email, name, role, is_active FROM users'
     );
     res.json(rows);
   } catch (err) {

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -19,10 +19,10 @@ async function run() {
 
     const passwordHash = await bcrypt.hash('1234', 10);
     await pool.query(
-      `INSERT INTO users (email, username, password, role)
-       VALUES ($1, $2, $3, $4)
+      `INSERT INTO users (name, email, password_hash, role, is_active)
+       VALUES ($1, $2, $3, $4, $5)
        ON CONFLICT (email) DO NOTHING`,
-      ['filipeoliveira@example.com', 'filipeoliveira', passwordHash, 'admin']
+      ['filipeoliveira', 'filipeoliveira@example.com', passwordHash, 'ADMIN', true]
     );
 
     console.log('Seeding completed successfully.');


### PR DESCRIPTION
## Summary
- replace users table columns with id, name, email, password_hash, role enum, is_active, timestamps
- update updated_at trigger and adjust routes and seed to new schema
- refresh client/admin pages and login flow for name and uppercase roles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a684f932388327ab66ff07e7e7f0ba