### PR TITLE
feat: log and verify database connection at startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -62,7 +62,20 @@ app.get('/db-health', async (req, res) => {
   }
 });
 
+const maskDbUrl = (url) => url ? url.replace(/:\/\/.*@/, '://***@') : '';
+
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+(async () => {
+  const dbUrl = process.env.DATABASE_URL || '';
+  const maskedUrl = maskDbUrl(dbUrl);
+  try {
+    await pool.query('SELECT 1');
+    console.log(`Connected to database ${maskedUrl}`);
+    app.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+    });
+  } catch (err) {
+    console.error(`Database connection error for ${maskedUrl}`, err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- verify database connectivity before starting server
- log masked `DATABASE_URL` and exit on failures

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a689a3bec88327a3561aae993115bd