### PR TITLE
Check inactive users during login

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -24,6 +24,10 @@ router.post('/login', async (req, res) => {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
 
+    if (!user.is_active) {
+      return res.status(403).json({ message: 'User inactive' });
+    }
+
     req.session.user = {
       id: user.id,
       email: user.email,


### PR DESCRIPTION
## Summary
- Prevent inactive accounts from logging in by returning 403 before creating session

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a68adf9df88327944e6eb9d41e1a61